### PR TITLE
Homepage cover image is not cut off anymore

### DIFF
--- a/app/assets/stylesheets/components/_cover.scss
+++ b/app/assets/stylesheets/components/_cover.scss
@@ -2,7 +2,9 @@
   height: 90vh;
   background-image: url(asset_path('cover.svg'));
   height: 600px;
-  background-size: cover;
+  background-size: contain;
+  background-repeat:no-repeat;
+  background-position: center;
   display: flex;
   justify-content: space-around;
   align-items: center;


### PR DESCRIPTION
I fixed the homepage cover image, it's not cut off anymore

to test, go onto the home page to see the cover